### PR TITLE
Updated build to support new scala bundles

### DIFF
--- a/org.svelto.plugin.feature/feature.xml
+++ b/org.svelto.plugin.feature/feature.xml
@@ -7,7 +7,7 @@
       plugin="org.svelto.plugin">
 
    <description url="http://www.scala-ide.org">
-      Svelto is a ligthweight performance monitoring tool. 
+      Svelto is a ligthweight performance monitoring tool.
 
 It automatically takes thread dumps when the UI thread is unresponsive.
    </description>
@@ -228,9 +228,14 @@ All rights reserved.
    <requires>
       <import plugin="org.eclipse.core.runtime"/>
       <import plugin="org.eclipse.ui"/>
-      <import plugin="org.scala-ide.scala.library"/>
    </requires>
 
+   <plugin
+         id="org.scala-lang.scala-library"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
    <plugin
          id="org.svelto.plugin"
          download-size="0"

--- a/org.svelto.plugin.source.feature/feature.xml
+++ b/org.svelto.plugin.source.feature/feature.xml
@@ -10,7 +10,7 @@
   </description>
 
    <copyright url="http://example.org/downloads/">
-      Copyright (C) 2012 ______TO_UPDATE_______. 
+      Copyright (C) 2012 ______TO_UPDATE_______.
 All rights reserved.
    </copyright>
 

--- a/org.svelto.plugin.source.feature/pom.xml
+++ b/org.svelto.plugin.source.feature/pom.xml
@@ -8,4 +8,5 @@
   </parent>
   <artifactId>org.svelto.plugin.source.feature</artifactId>
   <packaging>eclipse-feature</packaging>
+
 </project>

--- a/org.svelto.plugin.update-site/pom.xml
+++ b/org.svelto.plugin.update-site/pom.xml
@@ -9,4 +9,5 @@
   </parent>
   <artifactId>org.svelto.plugin.update-site</artifactId>
   <packaging>eclipse-update-site</packaging>
+
 </project>

--- a/org.svelto.plugin/META-INF/MANIFEST.MF
+++ b/org.svelto.plugin/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-Localization: plugin
 Require-Bundle: 
  org.eclipse.core.runtime,
  org.eclipse.ui,
- org.scala-ide.scala.library
+ org.scala-lang.scala-library
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-ClassPath: .
 Bundle-Activator: org.svelto.plugin.SveltoPlugin

--- a/pom.xml
+++ b/pom.xml
@@ -20,67 +20,58 @@
 
   <properties>
     <encoding>UTF-8</encoding>
-    <!-- p2 repositories location -->
-    <repo.eclipse.indigo>http://download.eclipse.org/releases/indigo/</repo.eclipse.indigo>
-    <repo.eclipse.juno>http://download.eclipse.org/releases/juno/</repo.eclipse.juno>
-    <repo.scala-ide.root>http://download.scala-ide.org</repo.scala-ide.root>
-
     <!-- fixed versions -->
-    <tycho.version>0.15.0</tycho.version>
-    <scala.plugin.version>3.0.2</scala.plugin.version>
+    <tycho.version>0.18.1</tycho.version>
+    <scala.plugin.version>3.1.5</scala.plugin.version>
 
     <!-- tycho test related -->
     <tycho.test.OSspecific></tycho.test.OSspecific>
     <tycho.test.jvmArgs>-Xmx800m -XX:MaxPermSize=256m -Dsdtcore.headless ${tycho.test.OSspecific}</tycho.test.jvmArgs>
 
     <!-- dependencies repos -->
-    <eclipse.codename>indigo</eclipse.codename>
-    <repo.eclipse>${repo.eclipse.indigo}</repo.eclipse>
+    <repo.eclipse.juno>http://download.eclipse.org/releases/juno</repo.eclipse.juno>
+    <eclipse.codename>juno</eclipse.codename>
+    <repo.eclipse>${repo.eclipse.juno}</repo.eclipse>
 
     <!-- some default values, can be overwritten by profiles -->
-    <scala.version>2.9.3</scala.version>
-    <version.suffix>2_09</version.suffix>
-    <scala.version.short>2.9</scala.version.short>
+    <scala.version>2.10.3</scala.version>
+    <version.suffix>2_10</version.suffix>
+    <scala.version.short>2.10</scala.version.short>
     <version.tag>local</version.tag>
-    <junit.version>4.10</junit.version>
    </properties>
 
-  <profiles>
-    <profile>
-      <!-- this is the default profile, using the stable Scala build-->
-      <id>scala-2.9</id>
-      <properties>
-        <repo.scala-ide>${repo.scala-ide.root}/sdk/next/e37/scala29/dev/base/</repo.scala-ide>
+   <profiles>
+     <profile>
+       <!-- Scala 2.10.x -->
+       <id>scala-2.10.x</id>
+       <properties>
       </properties>
     </profile>
     <profile>
-      <!-- Scala 2.10.x -->
-      <id>scala-2.10.x</id>
+      <!-- Scala 2.11.x -->
+      <id>scala-2.11.x</id>
       <properties>
-        <scala.version>2.10.1-RC2</scala.version>
-        <version.suffix>2_10</version.suffix>
-        <repo.scala-ide>${repo.scala-ide.root}/sdk/next/e37/scala210/dev/base/</repo.scala-ide>
-        <scala.version.short>2.10</scala.version.short>
+        <scala.version>2.11.0-SNAPSHOT</scala.version>
+        <version.suffix>2_11</version.suffix>
+        <scala.version.short>2.11</scala.version.short>
       </properties>
     </profile>
 
   </profiles>
 
   <!-- scm configuration is require to extract the github hash-->
-  <scm> 
-    <connection>scm:git://github.com/dragos/svelto.git</connection> 
-    <url>https://github.com/dragos/svelto.git</url> 
+  <scm>
+    <connection>scm:git://github.com/dragos/svelto.git</connection>
+    <url>https://github.com/dragos/svelto.git</url>
   </scm>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+  </dependencies>
 
   <repositories>
     <repository>
@@ -96,13 +87,6 @@
       <snapshots>
         <updatePolicy>daily</updatePolicy>
       </snapshots>
-    </repository>
-    <repository>
-      <id>scala-ide</id>
-      <name>Scala IDE p2 repository</name>
-      <layout>p2</layout>
-      <url>${repo.scala-ide}</url>
-      <snapshots><enabled>false</enabled></snapshots>
     </repository>
     <repository>
       <id>eclipse.${eclipse.codename}</id>
@@ -134,6 +118,16 @@
         <artifactId>tycho-maven-plugin</artifactId>
         <version>${tycho.version}</version>
         <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <!-- configuration to be able to use maven bundle as osgi bundles -->
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <resolver>p2</resolver>
+          <pomDependencies>consider</pomDependencies>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
- Cleaned-up the build as it does no longer need to depend on a scala-ide p2
  repo to retrieve the scala bundles (Tycho now uses plain maven dependencies).
- Dropped support for Scala 2.9 as it is incompatible with 2.10+. And added
  profile for compiling against Scala 2.11.
- Updated version of both Tycho and scala-maven plugin.

This PR should make @sschaef happy ;-)
